### PR TITLE
Rollup Timestream Query API support into existing PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix incorrect parse logic for timestamp headers in JSON based protocols
 - Update to botocore 1.19.12
 - Add Amazon Timestream write support, crate `rusoto_timestream_write`.
+- Add Amazon Timestream query support, crate `rusoto_timestream_query`.
 
 ## [0.45.0] - 2020-07-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,7 @@ members = [
     "rusoto/services/support",
     "rusoto/services/swf",
     "rusoto/services/textract",
+    "rusoto/services/timestream-query",
     "rusoto/services/timestream-write",
     "rusoto/services/transcribe",
     "rusoto/services/transfer",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -3,10 +3,10 @@ name = "rusoto_tests"
 description = "AWS SDK for Rust - Integration Tests"
 version = "0.45.0"
 authors = [
-    "Anthony DiMarco <ocramida@gmail.com>",
-    "Jimmy Cuadra <jimmy@jimmycuadra.com>",
-    "Matthew Mayer <matthewkmayer@gmail.com>",
-    "Nikita Pekin <contact@nikitapek.in>"
+	"Anthony DiMarco <ocramida@gmail.com>",
+	"Jimmy Cuadra <jimmy@jimmycuadra.com>",
+	"Matthew Mayer <matthewkmayer@gmail.com>",
+	"Nikita Pekin <contact@nikitapek.in>",
 ]
 license = "MIT"
 repository = "https://github.com/rusoto/rusoto"
@@ -338,8 +338,8 @@ optional = true
 path = "../rusoto/services/iot-jobs-data"
 
 [dependencies.rusoto_iotsecuretunneling]
- optional = true
- path = "../rusoto/services/iotsecuretunneling"
+optional = true
+path = "../rusoto/services/iotsecuretunneling"
 
 [dependencies.rusoto_kafka]
 optional = true
@@ -589,6 +589,10 @@ path = "../rusoto/services/support"
 optional = true
 path = "../rusoto/services/swf"
 
+[dependencies.rusoto_timestream_query]
+optional = true
+path = "../rusoto/services/timestream-query"
+
 [dependencies.rusoto_transcribe]
 optional = true
 path = "../rusoto/services/transcribe"
@@ -805,6 +809,7 @@ all = [
 	"sts",
 	"support",
 	"swf",
+	"timestream-query",
 	"transcribe",
 	"transfer",
 	"translate",
@@ -819,8 +824,8 @@ all = [
 	"apigatewaymanagementapi",
 	"apigatewayv2",
 	"ram",
-	"qldb"
-	]
+	"qldb",
+]
 core = []
 acm = ["rusoto_acm"]
 acm-pca = ["rusoto_acm_pca"]
@@ -963,6 +968,7 @@ storagegateway = ["rusoto_storagegateway"]
 sts = ["rusoto_sts", "rusoto_ec2"]
 support = ["rusoto_support"]
 swf = ["rusoto_swf"]
+timestream-query = ["rusoto_timestream_query"]
 transcribe = ["rusoto_transcribe"]
 transfer = ["rusoto_transfer"]
 translate = ["rusoto_translate"]

--- a/integration_tests/tests/timestream-query.rs
+++ b/integration_tests/tests/timestream-query.rs
@@ -1,0 +1,11 @@
+#![cfg(feature = "timestream-query")]
+
+use rusoto_core::Region;
+use rusoto_timestream_query::{TimestreamQuery, TimestreamQueryClient};
+
+#[tokio::test]
+async fn should_describe_endpoints() {
+	let client = TimestreamQueryClient::new(Region::UsEast1);
+
+    client.describe_endpoints().await.unwrap();
+}

--- a/rusoto/services/timestream-query/Cargo.toml
+++ b/rusoto/services/timestream-query/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
+description = "AWS SDK for Rust - Amazon Timestream Query @ 2018-11-01"
+documentation = "https://docs.rs/rusoto_timestream_query"
+keywords = ["AWS", "Amazon", "timestream-query"]
+license = "MIT"
+name = "rusoto_timestream_query"
+readme = "README.md"
+repository = "https://github.com/rusoto/rusoto"
+version = "0.45.0"
+homepage = "https://www.rusoto.org/"
+edition = "2018"
+exclude = ["test_resources/*"]
+[package.metadata.docs.rs]
+targets = []
+
+[build-dependencies]
+
+[dependencies]
+async-trait = "0.1"
+bytes = "0.5"
+serde_json = "1.0"
+
+[dependencies.futures]
+version = "0.3"
+
+[dependencies.rusoto_core]
+version = "0.45.0"
+path = "../../core"
+default-features = false
+
+[dependencies.serde]
+version = "1.0"
+features = ["derive"]
+
+[dev-dependencies]
+tokio = "0.2"
+
+[dev-dependencies.rusoto_mock]
+version = "0.45.0"
+path = "../../../mock"
+default-features = false
+
+[features]
+default = ["native-tls"]
+deserialize_structs = ["bytes/serde"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]
+serialize_structs = ["bytes/serde"]

--- a/rusoto/services/timestream-query/README.md
+++ b/rusoto/services/timestream-query/README.md
@@ -1,0 +1,53 @@
+
+# Rusoto TimestreamQuery
+Rust SDK for Amazon Timestream Query
+
+You may be looking for:
+
+* [An overview of Rusoto][rusoto-overview]
+* [AWS services supported by Rusoto][supported-aws-services]
+* [API documentation][api-documentation]
+* [Getting help with Rusoto][rusoto-help]
+
+## Requirements
+
+Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
+[`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
+
+On Linux, OpenSSL is required.
+
+## Installation
+
+To use `rusoto_timestream_query` in your application, add it as a dependency in your `Cargo.toml`:
+
+```toml
+[dependencies]
+rusoto_timestream_query = "0.45.0"
+```
+
+## Crate Features
+- `native-tls` - use platform-specific TLS implementation.
+- `rustls` - use rustls TLS implementation.
+- `serialize_structs` - output structs of most operations get `derive(Serialize)`.
+- `deserialize_structs` - input structs of most operations get `derive(Deserialize)`.
+
+Note: the crate will use the `native-tls` TLS implementation by default.
+
+## Contributing
+
+See [CONTRIBUTING][contributing].
+
+## License
+
+Rusoto is distributed under the terms of the MIT license.
+
+See [LICENSE][license] for details.
+
+[api-documentation]: https://docs.rs/rusoto_timestream_query "API documentation"
+[license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
+[contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
+[rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"
+[rusoto-overview]: https://www.rusoto.org/ "Rusoto overview"
+[supported-aws-services]: https://www.rusoto.org/supported-aws-services.html "List of AWS services supported by Rusoto"
+        

--- a/rusoto/services/timestream-query/src/custom/mod.rs
+++ b/rusoto/services/timestream-query/src/custom/mod.rs
@@ -1,0 +1,158 @@
+use crate::{
+    CancelQueryError, CancelQueryRequest, CancelQueryResponse, DescribeEndpointsError, QueryError,
+    QueryRequest, QueryResponse, TimestreamQuery, TimestreamQueryClient,
+};
+use rusoto_core::{
+    credential::ProvideAwsCredentials, Client, DispatchSignedRequest, Region, RusotoError,
+};
+use std::cmp::max;
+use std::ops::Add;
+use std::time::{Duration, Instant};
+
+#[derive(Clone)]
+struct Endpoint {
+    address: String,
+    expiry: Instant,
+}
+
+/// An endpoint-discovery-aware client for the Timestream Query API.
+///
+/// Amazon Timestream utilizes a segregated architecture to ensure better scaling and traffic isolation properties.
+/// Each system segment is managed through multiple endpoints, and your applications must use the correct endpoint
+/// while accessing the service. When using this client, these endpoint management tasks are transparently handled for you.
+/// However, when accessing the Timestream Query API using the default [`TimestreamQuery`] methods,
+/// you will need to manage and map the correct endpoints yourself. This process is called the endpoint discovery pattern,
+/// and is described [here](https://docs.aws.amazon.com/timestream/latest/developerguide/Using-API.endpoint-discovery.html).
+///
+/// # Examples
+///
+/// ```
+/// use rusoto_core::{Region, RusotoError};
+/// use rusoto_timestream_query::{QueryError, QueryResponse, QueryRequest, TimestreamQueryEndpointClient};
+///
+/// async fn query(query: QueryRequest) -> Result<QueryResponse, RusotoError<QueryError>> {
+///     let mut client = TimestreamQueryEndpointClient::new(Region::UsEast1);
+///     client.query(query).await
+/// }
+/// ```
+pub struct TimestreamQueryEndpointClient {
+    client: TimestreamQueryClient,
+    endpoint: Option<Endpoint>,
+    region: Region,
+}
+
+impl TimestreamQueryEndpointClient {
+    /// Creates a client backed by the default tokio event loop.
+    ///
+    /// The client will use the default credentials provider and tls client.
+    pub fn new(region: Region) -> Self {
+        Self {
+            client: TimestreamQueryClient::new(region.clone()),
+            endpoint: None,
+            region,
+        }
+    }
+
+    pub fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: Region) -> Self
+    where
+        P: ProvideAwsCredentials + Send + Sync + 'static,
+        D: DispatchSignedRequest + Send + Sync + 'static,
+    {
+        Self {
+            client: TimestreamQueryClient::new_with(
+                request_dispatcher,
+                credentials_provider,
+                region.clone(),
+            ),
+            endpoint: None,
+            region,
+        }
+    }
+
+    pub fn new_with_client(client: Client, region: Region) -> Self {
+        Self {
+            client: TimestreamQueryClient::new_with_client(client, region.clone()),
+            endpoint: None,
+            region,
+        }
+    }
+
+    async fn update_endpoint(&mut self) -> Result<(), RusotoError<DescribeEndpointsError>> {
+        match self.endpoint {
+            Some(ref e) if e.expiry > Instant::now() => Ok(()),
+            _ => {
+                let client = TimestreamQueryClient::new(self.region.clone());
+                let endpoint = client.describe_endpoints().await?.endpoints.pop().ok_or(
+                    RusotoError::Service(DescribeEndpointsError::InternalServer(
+                        "DescribeEndpoints API returned empty endpoint list".to_string(),
+                    )),
+                )?;
+
+                self.endpoint = Some(Endpoint {
+                    address: endpoint.address.clone(),
+                    // Subtract 1 minute from the TTL to ensure the endpoint data is refreshed before it expires.
+                    expiry: Instant::now().add(Duration::from_secs(max(
+                        5,
+                        endpoint.cache_period_in_minutes as u64 * 60 - 60,
+                    ))),
+                });
+                self.client = TimestreamQueryClient::new(Region::Custom {
+                    name: self.region.name().to_string(),
+                    endpoint: endpoint.address,
+                });
+
+                Ok(())
+            }
+        }
+    }
+
+    /// <p> Cancels a query that has been issued. Cancellation is guaranteed only if the query has not completed execution before the cancellation request was issued. Because cancellation is an idempotent operation, subsequent cancellation requests will return a <code>CancellationMessage</code>, indicating that the query has already been canceled. </p>
+    pub async fn cancel_query(
+        &mut self,
+        input: CancelQueryRequest,
+    ) -> Result<CancelQueryResponse, RusotoError<CancelQueryError>> {
+        self.update_endpoint().await.map_err(|e| match e {
+            // Remap any DescribeEndpointError to WriteRecordErrors
+            RusotoError::Service(DescribeEndpointsError::Throttling(s)) => {
+                RusotoError::Service(CancelQueryError::Throttling(s))
+            }
+            RusotoError::Service(DescribeEndpointsError::InternalServer(s)) => {
+                RusotoError::Service(CancelQueryError::InternalServer(s))
+            }
+            // Pass on all non-service related errors as is.
+            RusotoError::Blocking => RusotoError::Blocking,
+            RusotoError::Credentials(e) => RusotoError::Credentials(e),
+            RusotoError::HttpDispatch(e) => RusotoError::HttpDispatch(e),
+            RusotoError::ParseError(e) => RusotoError::ParseError(e),
+            RusotoError::Unknown(e) => RusotoError::Unknown(e),
+            RusotoError::Validation(e) => RusotoError::Validation(e),
+        })?;
+
+        self.client.cancel_query(input).await
+    }
+
+    /// <p> Query is a synchronous operation that enables you to execute a query. Query will timeout after 60 seconds. You must update the default timeout in the SDK to support a timeout of 60 seconds. The result set will be truncated to 1MB. Service quotas apply. For more information, see Quotas in the Timestream Developer Guide. </p>
+    pub async fn query(
+        &mut self,
+        input: QueryRequest,
+    ) -> Result<QueryResponse, RusotoError<QueryError>> {
+        self.update_endpoint().await.map_err(|e| match e {
+            // Remap any DescribeEndpointError to WriteRecordErrors
+            RusotoError::Service(DescribeEndpointsError::Throttling(s)) => {
+                RusotoError::Service(QueryError::Throttling(s))
+            }
+            RusotoError::Service(DescribeEndpointsError::InternalServer(s)) => {
+                RusotoError::Service(QueryError::InternalServer(s))
+            }
+            // Pass on all non-service related errors as is.
+            RusotoError::Blocking => RusotoError::Blocking,
+            RusotoError::Credentials(e) => RusotoError::Credentials(e),
+            RusotoError::HttpDispatch(e) => RusotoError::HttpDispatch(e),
+            RusotoError::ParseError(e) => RusotoError::ParseError(e),
+            RusotoError::Unknown(e) => RusotoError::Unknown(e),
+            RusotoError::Validation(e) => RusotoError::Validation(e),
+        })?;
+
+        self.client.query(input).await
+    }
+}

--- a/rusoto/services/timestream-query/src/generated.rs
+++ b/rusoto/services/timestream-query/src/generated.rs
@@ -1,0 +1,462 @@
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+
+use std::error::Error;
+use std::fmt;
+
+use async_trait::async_trait;
+use rusoto_core::credential::ProvideAwsCredentials;
+use rusoto_core::region;
+use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
+use rusoto_core::{Client, RusotoError};
+
+use rusoto_core::proto;
+use rusoto_core::request::HttpResponse;
+use rusoto_core::signature::SignedRequest;
+#[allow(unused_imports)]
+use serde::{Deserialize, Serialize};
+
+impl TimestreamQueryClient {
+    fn new_signed_request(&self, http_method: &str, request_uri: &str) -> SignedRequest {
+        let mut request = SignedRequest::new(http_method, "timestream", &self.region, request_uri);
+        request.set_endpoint_prefix("query.timestream".to_string());
+
+        request.set_content_type("application/x-amz-json-1.0".to_owned());
+
+        request
+    }
+
+    async fn sign_and_dispatch<E>(
+        &self,
+        request: SignedRequest,
+        from_response: fn(BufferedHttpResponse) -> RusotoError<E>,
+    ) -> Result<HttpResponse, RusotoError<E>> {
+        let mut response = self.client.sign_and_dispatch(request).await?;
+        if !response.status.is_success() {
+            let response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
+            return Err(from_response(response));
+        }
+
+        Ok(response)
+    }
+}
+
+use serde_json;
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "deserialize_structs", derive(Deserialize))]
+pub struct CancelQueryRequest {
+    /// <p> The id of the query that needs to be cancelled. <code>QueryID</code> is returned as part of QueryResult. </p>
+    #[serde(rename = "QueryId")]
+    pub query_id: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[cfg_attr(any(test, feature = "serialize_structs"), derive(Serialize))]
+pub struct CancelQueryResponse {
+    /// <p> A <code>CancellationMessage</code> is returned when a <code>CancelQuery</code> request for the query specified by <code>QueryId</code> has already been issued. </p>
+    #[serde(rename = "CancellationMessage")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancellation_message: Option<String>,
+}
+
+/// <p> Contains the meta data for query results such as the column names, data types, and other attributes. </p>
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[cfg_attr(any(test, feature = "serialize_structs"), derive(Serialize))]
+pub struct ColumnInfo {
+    /// <p> The name of the result set column. The name of the result set is available for columns of all data types except for arrays. </p>
+    #[serde(rename = "Name")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// <p> The data type of the result set column. The data type can be a scalar or complex. Scalar data types are integers, strings, doubles, booleans, and others. Complex data types are types such as arrays, rows, and others. </p>
+    #[serde(rename = "Type")]
+    pub type_: Box<Type>,
+}
+
+/// <p> Datum represents a single data point in a query result. </p>
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[cfg_attr(any(test, feature = "serialize_structs"), derive(Serialize))]
+pub struct Datum {
+    /// <p> Indicates if the data point is an array. </p>
+    #[serde(rename = "ArrayValue")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub array_value: Option<Vec<Datum>>,
+    /// <p> Indicates if the data point is null. </p>
+    #[serde(rename = "NullValue")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub null_value: Option<bool>,
+    /// <p> Indicates if the data point is a row. </p>
+    #[serde(rename = "RowValue")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub row_value: Option<Row>,
+    /// <p> Indicates if the data point is a scalar value such as integer, string, double, or boolean. </p>
+    #[serde(rename = "ScalarValue")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scalar_value: Option<String>,
+    /// <p> Indicates if the data point is of timeseries data type. </p>
+    #[serde(rename = "TimeSeriesValue")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_series_value: Option<Vec<TimeSeriesDataPoint>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "deserialize_structs", derive(Deserialize))]
+pub struct DescribeEndpointsRequest {}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[cfg_attr(any(test, feature = "serialize_structs"), derive(Serialize))]
+pub struct DescribeEndpointsResponse {
+    /// <p>An <code>Endpoints</code> object is returned when a <code>DescribeEndpoints</code> request is made.</p>
+    #[serde(rename = "Endpoints")]
+    pub endpoints: Vec<Endpoint>,
+}
+
+/// <p>Represents an available endpoint against which to make API calls agaisnt, as well as the TTL for that endpoint.</p>
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[cfg_attr(any(test, feature = "serialize_structs"), derive(Serialize))]
+pub struct Endpoint {
+    /// <p>An endpoint address.</p>
+    #[serde(rename = "Address")]
+    pub address: String,
+    /// <p>The TTL for the endpoint, in minutes.</p>
+    #[serde(rename = "CachePeriodInMinutes")]
+    pub cache_period_in_minutes: i64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[cfg_attr(feature = "deserialize_structs", derive(Deserialize))]
+pub struct QueryRequest {
+    /// <p> Unique, case-sensitive string of up to 64 ASCII characters that you specify when you make a Query request. Providing a <code>ClientToken</code> makes the call to <code>Query</code> idempotent, meaning that multiple identical calls have the same effect as one single call. </p> <p>Your query request will fail in the following cases:</p> <ul> <li> <p> If you submit a request with the same client token outside the 5-minute idepotency window. </p> </li> <li> <p> If you submit a request with the same client token but a change in other parameters within the 5-minute idempotency window. </p> </li> </ul> <p> After 4 hours, any request with the same client token is treated as a new request. </p>
+    #[serde(rename = "ClientToken")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_token: Option<String>,
+    /// <p> The total number of rows to return in the output. If the total number of rows available is more than the value specified, a NextToken is provided in the command's output. To resume pagination, provide the NextToken value in the starting-token argument of a subsequent command. </p>
+    #[serde(rename = "MaxRows")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_rows: Option<i64>,
+    /// <p> A pagination token passed to get a set of results. </p>
+    #[serde(rename = "NextToken")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_token: Option<String>,
+    /// <p> The query to be executed by Timestream. </p>
+    #[serde(rename = "QueryString")]
+    pub query_string: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[cfg_attr(any(test, feature = "serialize_structs"), derive(Serialize))]
+pub struct QueryResponse {
+    /// <p> The column data types of the returned result set. </p>
+    #[serde(rename = "ColumnInfo")]
+    pub column_info: Vec<ColumnInfo>,
+    /// <p> A pagination token that can be used again on a <code>Query</code> call to get the next set of results. </p>
+    #[serde(rename = "NextToken")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_token: Option<String>,
+    /// <p> A unique ID for the given query. </p>
+    #[serde(rename = "QueryId")]
+    pub query_id: String,
+    /// <p> The result set rows returned by the query. </p>
+    #[serde(rename = "Rows")]
+    pub rows: Vec<Row>,
+}
+
+/// <p>Represents a single row in the query results.</p>
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[cfg_attr(any(test, feature = "serialize_structs"), derive(Serialize))]
+pub struct Row {
+    /// <p>List of data points in a single row of the result set.</p>
+    #[serde(rename = "Data")]
+    pub data: Vec<Datum>,
+}
+
+/// <p>The timeseries datatype represents the values of a measure over time. A time series is an array of rows of timestamps and measure values, with rows sorted in ascending order of time. A TimeSeriesDataPoint is a single data point in the timeseries. It represents a tuple of (time, measure value) in a timeseries. </p>
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[cfg_attr(any(test, feature = "serialize_structs"), derive(Serialize))]
+pub struct TimeSeriesDataPoint {
+    /// <p>The timestamp when the measure value was collected.</p>
+    #[serde(rename = "Time")]
+    pub time: String,
+    /// <p>The measure value for the data point.</p>
+    #[serde(rename = "Value")]
+    pub value: Datum,
+}
+
+/// <p>Contains the data type of a column in a query result set. The data type can be scalar or complex. The supported scalar data types are integers, boolean, string, double, timestamp, date, time, and intervals. The supported complex data types are arrays, rows, and timeseries.</p>
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[cfg_attr(any(test, feature = "serialize_structs"), derive(Serialize))]
+pub struct Type {
+    /// <p>Indicates if the column is an array.</p>
+    #[serde(rename = "ArrayColumnInfo")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub array_column_info: Option<ColumnInfo>,
+    /// <p>Indicates if the column is a row.</p>
+    #[serde(rename = "RowColumnInfo")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub row_column_info: Option<Vec<ColumnInfo>>,
+    /// <p>Indicates if the column is of type string, integer, boolean, double, timestamp, date, time. </p>
+    #[serde(rename = "ScalarType")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scalar_type: Option<String>,
+    /// <p>Indicates if the column is a timeseries data type.</p>
+    #[serde(rename = "TimeSeriesMeasureValueColumnInfo")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_series_measure_value_column_info: Option<ColumnInfo>,
+}
+
+/// Errors returned by CancelQuery
+#[derive(Debug, PartialEq)]
+pub enum CancelQueryError {
+    /// <p> You are not authorized to perform this action. </p>
+    AccessDenied(String),
+    /// <p> Timestream was unable to fully process this request because of an internal server error. </p>
+    InternalServer(String),
+    /// <p>The requested endpoint was invalid.</p>
+    InvalidEndpoint(String),
+    /// <p>The request was denied due to request throttling.</p>
+    Throttling(String),
+}
+
+impl CancelQueryError {
+    pub fn from_response(res: BufferedHttpResponse) -> RusotoError<CancelQueryError> {
+        if let Some(err) = proto::json::Error::parse(&res) {
+            match err.typ.as_str() {
+                "AccessDeniedException" => {
+                    return RusotoError::Service(CancelQueryError::AccessDenied(err.msg))
+                }
+                "InternalServerException" => {
+                    return RusotoError::Service(CancelQueryError::InternalServer(err.msg))
+                }
+                "InvalidEndpointException" => {
+                    return RusotoError::Service(CancelQueryError::InvalidEndpoint(err.msg))
+                }
+                "ThrottlingException" => {
+                    return RusotoError::Service(CancelQueryError::Throttling(err.msg))
+                }
+                "ValidationException" => return RusotoError::Validation(err.msg),
+                _ => {}
+            }
+        }
+        RusotoError::Unknown(res)
+    }
+}
+impl fmt::Display for CancelQueryError {
+    #[allow(unused_variables)]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            CancelQueryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            CancelQueryError::InternalServer(ref cause) => write!(f, "{}", cause),
+            CancelQueryError::InvalidEndpoint(ref cause) => write!(f, "{}", cause),
+            CancelQueryError::Throttling(ref cause) => write!(f, "{}", cause),
+        }
+    }
+}
+impl Error for CancelQueryError {}
+/// Errors returned by DescribeEndpoints
+#[derive(Debug, PartialEq)]
+pub enum DescribeEndpointsError {
+    /// <p> Timestream was unable to fully process this request because of an internal server error. </p>
+    InternalServer(String),
+    /// <p>The request was denied due to request throttling.</p>
+    Throttling(String),
+}
+
+impl DescribeEndpointsError {
+    pub fn from_response(res: BufferedHttpResponse) -> RusotoError<DescribeEndpointsError> {
+        if let Some(err) = proto::json::Error::parse(&res) {
+            match err.typ.as_str() {
+                "InternalServerException" => {
+                    return RusotoError::Service(DescribeEndpointsError::InternalServer(err.msg))
+                }
+                "ThrottlingException" => {
+                    return RusotoError::Service(DescribeEndpointsError::Throttling(err.msg))
+                }
+                "ValidationException" => return RusotoError::Validation(err.msg),
+                _ => {}
+            }
+        }
+        RusotoError::Unknown(res)
+    }
+}
+impl fmt::Display for DescribeEndpointsError {
+    #[allow(unused_variables)]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DescribeEndpointsError::InternalServer(ref cause) => write!(f, "{}", cause),
+            DescribeEndpointsError::Throttling(ref cause) => write!(f, "{}", cause),
+        }
+    }
+}
+impl Error for DescribeEndpointsError {}
+/// Errors returned by Query
+#[derive(Debug, PartialEq)]
+pub enum QueryError {
+    /// <p> You are not authorized to perform this action. </p>
+    AccessDenied(String),
+    /// <p> Unable to poll results for a cancelled query. </p>
+    Conflict(String),
+    /// <p> Timestream was unable to fully process this request because of an internal server error. </p>
+    InternalServer(String),
+    /// <p>The requested endpoint was invalid.</p>
+    InvalidEndpoint(String),
+    /// <p> Timestream was unable to run the query successfully. </p>
+    QueryExecution(String),
+    /// <p>The request was denied due to request throttling.</p>
+    Throttling(String),
+}
+
+impl QueryError {
+    pub fn from_response(res: BufferedHttpResponse) -> RusotoError<QueryError> {
+        if let Some(err) = proto::json::Error::parse(&res) {
+            match err.typ.as_str() {
+                "AccessDeniedException" => {
+                    return RusotoError::Service(QueryError::AccessDenied(err.msg))
+                }
+                "ConflictException" => return RusotoError::Service(QueryError::Conflict(err.msg)),
+                "InternalServerException" => {
+                    return RusotoError::Service(QueryError::InternalServer(err.msg))
+                }
+                "InvalidEndpointException" => {
+                    return RusotoError::Service(QueryError::InvalidEndpoint(err.msg))
+                }
+                "QueryExecutionException" => {
+                    return RusotoError::Service(QueryError::QueryExecution(err.msg))
+                }
+                "ThrottlingException" => {
+                    return RusotoError::Service(QueryError::Throttling(err.msg))
+                }
+                "ValidationException" => return RusotoError::Validation(err.msg),
+                _ => {}
+            }
+        }
+        RusotoError::Unknown(res)
+    }
+}
+impl fmt::Display for QueryError {
+    #[allow(unused_variables)]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            QueryError::AccessDenied(ref cause) => write!(f, "{}", cause),
+            QueryError::Conflict(ref cause) => write!(f, "{}", cause),
+            QueryError::InternalServer(ref cause) => write!(f, "{}", cause),
+            QueryError::InvalidEndpoint(ref cause) => write!(f, "{}", cause),
+            QueryError::QueryExecution(ref cause) => write!(f, "{}", cause),
+            QueryError::Throttling(ref cause) => write!(f, "{}", cause),
+        }
+    }
+}
+impl Error for QueryError {}
+/// Trait representing the capabilities of the Timestream Query API. Timestream Query clients implement this trait.
+#[async_trait]
+pub trait TimestreamQuery {
+    /// <p> Cancels a query that has been issued. Cancellation is guaranteed only if the query has not completed execution before the cancellation request was issued. Because cancellation is an idempotent operation, subsequent cancellation requests will return a <code>CancellationMessage</code>, indicating that the query has already been canceled. </p>
+    async fn cancel_query(
+        &self,
+        input: CancelQueryRequest,
+    ) -> Result<CancelQueryResponse, RusotoError<CancelQueryError>>;
+
+    /// <p>DescribeEndpoints returns a list of available endpoints to make Timestream API calls against. This API is available through both Write and Query.</p> <p>Because Timestream’s SDKs are designed to transparently work with the service’s architecture, including the management and mapping of the service endpoints, <i>it is not recommended that you use this API unless</i>:</p> <ul> <li> <p>Your application uses a programming language that does not yet have SDK support</p> </li> <li> <p>You require better control over the client-side implementation</p> </li> </ul> <p>For detailed information on how to use DescribeEndpoints, see <a href="https://docs.aws.amazon.com/timestream/latest/developerguide/Using-API.endpoint-discovery.html">The Endpoint Discovery Pattern and REST APIs</a>.</p>
+    async fn describe_endpoints(
+        &self,
+    ) -> Result<DescribeEndpointsResponse, RusotoError<DescribeEndpointsError>>;
+
+    /// <p> Query is a synchronous operation that enables you to execute a query. Query will timeout after 60 seconds. You must update the default timeout in the SDK to support a timeout of 60 seconds. The result set will be truncated to 1MB. Service quotas apply. For more information, see Quotas in the Timestream Developer Guide. </p>
+    async fn query(&self, input: QueryRequest) -> Result<QueryResponse, RusotoError<QueryError>>;
+}
+/// A client for the Timestream Query API.
+#[derive(Clone)]
+pub struct TimestreamQueryClient {
+    client: Client,
+    region: region::Region,
+}
+
+impl TimestreamQueryClient {
+    /// Creates a client backed by the default tokio event loop.
+    ///
+    /// The client will use the default credentials provider and tls client.
+    pub fn new(region: region::Region) -> TimestreamQueryClient {
+        TimestreamQueryClient {
+            client: Client::shared(),
+            region,
+        }
+    }
+
+    pub fn new_with<P, D>(
+        request_dispatcher: D,
+        credentials_provider: P,
+        region: region::Region,
+    ) -> TimestreamQueryClient
+    where
+        P: ProvideAwsCredentials + Send + Sync + 'static,
+        D: DispatchSignedRequest + Send + Sync + 'static,
+    {
+        TimestreamQueryClient {
+            client: Client::new_with(credentials_provider, request_dispatcher),
+            region,
+        }
+    }
+
+    pub fn new_with_client(client: Client, region: region::Region) -> TimestreamQueryClient {
+        TimestreamQueryClient { client, region }
+    }
+}
+
+#[async_trait]
+impl TimestreamQuery for TimestreamQueryClient {
+    /// <p> Cancels a query that has been issued. Cancellation is guaranteed only if the query has not completed execution before the cancellation request was issued. Because cancellation is an idempotent operation, subsequent cancellation requests will return a <code>CancellationMessage</code>, indicating that the query has already been canceled. </p>
+    async fn cancel_query(
+        &self,
+        input: CancelQueryRequest,
+    ) -> Result<CancelQueryResponse, RusotoError<CancelQueryError>> {
+        let mut request = self.new_signed_request("POST", "/");
+        request.add_header("x-amz-target", "Timestream_20181101.CancelQuery");
+        let encoded = serde_json::to_string(&input).unwrap();
+        request.set_payload(Some(encoded));
+
+        let response = self
+            .sign_and_dispatch(request, CancelQueryError::from_response)
+            .await?;
+        let mut response = response;
+        let response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
+        proto::json::ResponsePayload::new(&response).deserialize::<CancelQueryResponse, _>()
+    }
+
+    /// <p>DescribeEndpoints returns a list of available endpoints to make Timestream API calls against. This API is available through both Write and Query.</p> <p>Because Timestream’s SDKs are designed to transparently work with the service’s architecture, including the management and mapping of the service endpoints, <i>it is not recommended that you use this API unless</i>:</p> <ul> <li> <p>Your application uses a programming language that does not yet have SDK support</p> </li> <li> <p>You require better control over the client-side implementation</p> </li> </ul> <p>For detailed information on how to use DescribeEndpoints, see <a href="https://docs.aws.amazon.com/timestream/latest/developerguide/Using-API.endpoint-discovery.html">The Endpoint Discovery Pattern and REST APIs</a>.</p>
+    async fn describe_endpoints(
+        &self,
+    ) -> Result<DescribeEndpointsResponse, RusotoError<DescribeEndpointsError>> {
+        let mut request = self.new_signed_request("POST", "/");
+        request.add_header("x-amz-target", "Timestream_20181101.DescribeEndpoints");
+        request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
+
+        let response = self
+            .sign_and_dispatch(request, DescribeEndpointsError::from_response)
+            .await?;
+        let mut response = response;
+        let response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
+        proto::json::ResponsePayload::new(&response).deserialize::<DescribeEndpointsResponse, _>()
+    }
+
+    /// <p> Query is a synchronous operation that enables you to execute a query. Query will timeout after 60 seconds. You must update the default timeout in the SDK to support a timeout of 60 seconds. The result set will be truncated to 1MB. Service quotas apply. For more information, see Quotas in the Timestream Developer Guide. </p>
+    async fn query(&self, input: QueryRequest) -> Result<QueryResponse, RusotoError<QueryError>> {
+        let mut request = self.new_signed_request("POST", "/");
+        request.add_header("x-amz-target", "Timestream_20181101.Query");
+        let encoded = serde_json::to_string(&input).unwrap();
+        request.set_payload(Some(encoded));
+
+        let response = self
+            .sign_and_dispatch(request, QueryError::from_response)
+            .await?;
+        let mut response = response;
+        let response = response.buffer().await.map_err(RusotoError::HttpDispatch)?;
+        proto::json::ResponsePayload::new(&response).deserialize::<QueryResponse, _>()
+    }
+}

--- a/rusoto/services/timestream-query/src/lib.rs
+++ b/rusoto/services/timestream-query/src/lib.rs
@@ -1,0 +1,22 @@
+// =================================================================
+//
+//                           * WARNING *
+//
+//                    This file is generated!
+//
+//  Changes made to this file will be overwritten. If changes are
+//  required to the generated code, the service_crategen project
+//  must be updated to generate the changes.
+//
+// =================================================================
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/rusoto/rusoto/master/assets/logo-square.png"
+)]
+//! <p> </p>
+//!
+//! If you're using the service, you're probably looking for [TimestreamQueryClient](struct.TimestreamQueryClient.html) and [TimestreamQuery](trait.TimestreamQuery.html).
+
+mod custom;
+mod generated;
+pub use custom::*;
+pub use generated::*;

--- a/service_crategen/services.json
+++ b/service_crategen/services.json
@@ -1233,6 +1233,12 @@
     "protocolVersion": "2018-06-27",
     "baseTypeName": "Textract"
   },
+  "timestream-query": {
+    "version": "0.45.0",
+    "coreVersion": "0.45.0",
+    "protocolVersion": "2018-11-01",
+    "baseTypeName": "TimestreamQuery"
+  },
   "timestream-write": {
     "version": "0.45.0",
     "coreVersion": "0.45.0",

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -762,6 +762,11 @@ fn generate_struct_fields<P: GenerateProtocol>(
             // does not mention that the slot values themselves can be null.
             } else if service.name() == "Amazon Lex Runtime Service"  && shape_name == "PostTextResponse" && name == "slots"{
                 lines.push(format!("pub {}: Option<::std::collections::HashMap<String, Option<String>>>,", name))
+			// In the official documentation the field type is required, but Type can contain
+			// a ColumnInfo, causing an infinite recursion; we need to treat the type field as if it were
+			// an instance of ColumnInfo, as seen above.
+			} else if service.name() == "Timestream Query" && shape_name == "ColumnInfo" && rs_type == "Type" {
+                lines.push(format!("pub {}: Box<{}>,", name, rs_type))
             } else if name == "match" {
                 lines.push(format!("pub route_{}: Option<{}>,", name, rs_type))
             } else if shape.required(member_name) {


### PR DESCRIPTION
This PR adds support for the [Amazon TimeStream Query API](https://docs.aws.amazon.com/timestream/latest/developerguide/API_Types_Amazon_Timestream_Query.html) to the rusoto#1857 PR.

I thought it was best to add TimeStream Query API support to the existing TimeStream Write API PR, instead of having two separate PRs for the different TimeStream APIs (which will hopefully result in a faster merge upstream). I also included an endpoint-discovery-aware client as well, to try and keep the crates somewhat consistent.